### PR TITLE
Fix to deeply nested JSON parsing

### DIFF
--- a/scripts/__lexicon_text_struct_to_string/__lexicon_text_struct_to_string.gml
+++ b/scripts/__lexicon_text_struct_to_string/__lexicon_text_struct_to_string.gml
@@ -3,10 +3,11 @@ function __lexicon_text_struct_to_string(_textName, _textStruct) {
 	var _i = 0;
 	var _textArray = variable_struct_get_names(_textStruct);
 	repeat(array_length(_textArray)) {
+		var _textKey = _textName + LEXICON_TEXT_JSON_BREAK + _textArray[_i];
 		if (is_struct(_textStruct[$ _textArray[_i]])) {
-			__lexicon_text_struct_to_string(_textArray[_i], _textStruct[$ _textArray[_i]]);
+			__lexicon_text_struct_to_string(_textKey, _textStruct[$ _textArray[_i]]);
 		} else {
-			__LEXICON_STRUCT.textEntries[$ _textName + LEXICON_TEXT_JSON_BREAK + _textArray[_i]] = _textStruct[$ _textArray[_i]];	
+			__LEXICON_STRUCT.textEntries[$ _textKey] = _textStruct[$ _textArray[_i]];
 		}
 		++_i;
 	}


### PR DESCRIPTION
Previously the following translation file would generate the verb `"exit.confirmation"`:
```json
{
    "language": "Portuguese",
    "locale": "pt-PT",
    "text": {
        "ui": {
            "exit": {
                "confirmation": "Tens a certeza que queres sair?"
            }
        }
    }
}
```
I expect this to generate `"ui.exit.confirmation"`, the following change fixes this issue.

If anything needs to change please let me know! 。.:☆*:･'(\*^―^\*)))